### PR TITLE
make class order alphabetic in predict response

### DIFF
--- a/wot-backend/application/components/prediction/settings.py
+++ b/wot-backend/application/components/prediction/settings.py
@@ -1,3 +1,2 @@
-categories = ['Asteroid', 'Astronaut', 'Brief', 'Ufo', 'Versorgungsbox',
-       'Auto', 'Satellit', 'Satellitenschüssel',
-       'Raumschiff']
+categories = ['Asteroid','Astronaut','Auto','Brief',
+'Raumschiff','Satellit', 'Satellitenschüssel', 'Ufo', 'Versorgungsbox']


### PR DESCRIPTION
Changed the Order of the Response in Predict Endpoint. Now its in Alphabetic Order 